### PR TITLE
style(codeclimate): disable import/no-unresolved

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,9 @@ engines:
     channel: eslint-2
     config:
       config: ".eslintrc.js"
+    checks:
+      import/no-unresolved:
+        enabled: false
   fixme:
     enabled: true
   markdownlint:


### PR DESCRIPTION
Code climate doesn't install node modules so some imports
will never be resolved there. Travis already performs this check.